### PR TITLE
Resolve logger naming clash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 
 # Output of packages
 /pkg
+
+# Jetbrains IDE
+.idea*


### PR DESCRIPTION
Just a couple minor tweaks:
- Renames the instantiated logger from `log` to `logger` to avoid a naming clash with the imported `"log"` package
- Uses the `DefaultVaultAddr` where intended