### PR TITLE
Add concrete example of my-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,8 @@ $ cf create-service hashicorp-vault shared my-vault
 ```
 
 With a service instance in place, you are ready to bind an app. Suppose we have
-an app called 'my-app'.
+an app called 'my-app'. An example of my-app can be found at 
+https://github.com/tyrannosaurus-becks/cf-sample-app-go, along with instructions on how to deploy it.
 
 ```shell
 $ cf bind-service my-app my-vault


### PR DESCRIPTION
Adds a reference to an example of "my-app" as noted in the docs. The referenced example provides clear and easy instructions on how to deploy it. This couldn't be included in this app because Cloud Foundry requires one GH repo per app.