### PR TITLE
Don't error if token doesnt require renewal

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -695,8 +695,6 @@ func (b *Broker) renewAuth(token, accessor string, stopCh <-chan struct{}) {
 // renewVaultToken is a convenience wrapper around renewAuth which looks up
 // metadata about the token attached to this broker and starts the renewer.
 func (b *Broker) renewVaultToken() {
-	// We would like to use lookup-self here, but that does not include the auth
-	// data we need back...
 	secret, err := b.client.Auth().Token().LookupSelf()
 	if err != nil {
 		b.log.Printf("[ERR] renew-token: failed to lookup client vault token: %s", err)


### PR DESCRIPTION
Fixes #25 

When using the root token as the broker's `VAULT_TOKEN`, an error was occurring in the broker's `Start` method stating the token couldn't be renewed. It turned out this was because the root token doesn't have a lease and never expires, so it can't be renewed.

This code adds a check for whether tokens are renewable and resolves the error.