### PR TITLE
Add application-level secrets engines

### DIFF
--- a/broker_test.go
+++ b/broker_test.go
@@ -71,9 +71,12 @@ func TestBroker_Bind_Unbind(t *testing.T) {
 	env.Broker.instances["instance-id"] = &instanceInfo{
 		SpaceGUID:        "space-guid",
 		OrganizationGUID: "organization-guid",
+		ServiceInstanceGUID: "instance-id",
 	}
 
-	binding, err := env.Broker.Bind(env.Context, env.InstanceID, env.BindingID, brokerapi.BindDetails{})
+	binding, err := env.Broker.Bind(env.Context, env.InstanceID, env.BindingID, brokerapi.BindDetails{
+		AppGUID: "app-id",
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -273,6 +276,10 @@ func defaultEnvironment(t *testing.T) (*Environment, func()) {
 			w.WriteHeader(204)
 			return
 
+		case reqURL == "/v1/cf/broker/app-id" && r.Method == "PUT":
+			w.WriteHeader(204)
+			return
+
 		case reqURL == "/v1/cf/broker/instance-id/binding-id" && r.Method == "PUT":
 			w.WriteHeader(204)
 			return
@@ -332,6 +339,14 @@ func defaultEnvironment(t *testing.T) (*Environment, func()) {
 			return
 
 		case reqURL == "/v1/sys/mounts/cf/instance-id/transit" && r.Method == "POST":
+			w.WriteHeader(204)
+			return
+
+		case reqURL == "/v1/sys/mounts/cf/app-id/secret" && r.Method == "POST":
+			w.WriteHeader(204)
+			return
+
+		case reqURL == "/v1/sys/mounts/cf/app-id/transit" && r.Method == "POST":
 			w.WriteHeader(204)
 			return
 

--- a/vault.go
+++ b/vault.go
@@ -25,6 +25,14 @@ path "cf/{{ .SpaceGUID }}/*" {
   capabilities = ["create", "read", "update", "delete", "list"]
 }
 
+path "cf/{{ .ApplicationGUID }}" {
+  capabilities = ["list"]
+}
+
+path "cf/{{ .ApplicationGUID }}/*" {
+  capabilities = ["create", "read", "update", "delete", "list"]
+}
+
 path "cf/{{ .OrganizationGUID }}" {
   capabilities = ["list"]
 }


### PR DESCRIPTION
Adds an application-level secrets and transit engine. Since an application ID isn't sent until the `Bind` call, this is mounted at that time as well. To do that, policy generation must be moved to that method too. 

Note: There's a breaking API change in the response that's returned from the `Bind` call, so this will need to be in a major release.