### PR TITLE
Fix application id issue

### DIFF
--- a/broker_test.go
+++ b/broker_test.go
@@ -33,7 +33,7 @@ func TestBroker_Services(t *testing.T) {
 
 	services := env.Broker.Services(env.Context)
 	if len(services) != 1 {
-		t.Fatalf("expectedWithAppID 1 service but received %d", len(services))
+		t.Fatalf("expected 1 service but received %d", len(services))
 	}
 }
 
@@ -81,31 +81,31 @@ func TestBroker_Bind_Unbind(t *testing.T) {
 		t.Fatal(err)
 	}
 	if binding.SyslogDrainURL != "" {
-		t.Fatalf("expectedWithAppID empty SyslogDrainURL but received %s", binding.SyslogDrainURL)
+		t.Fatalf("expected empty SyslogDrainURL but received %s", binding.SyslogDrainURL)
 	}
 	if binding.RouteServiceURL != "" {
-		t.Fatalf("expectedWithAppID empty RouteServiceURL but received %s", binding.RouteServiceURL)
+		t.Fatalf("expected empty RouteServiceURL but received %s", binding.RouteServiceURL)
 	}
 	if len(binding.VolumeMounts) != 0 {
-		t.Fatalf("expectedWithAppID no VolumeMounts but received %+v", binding.VolumeMounts)
+		t.Fatalf("expected no VolumeMounts but received %+v", binding.VolumeMounts)
 	}
 	credMap, ok := binding.Credentials.(map[string]interface{})
 	if !ok {
-		t.Fatalf("expectedWithAppID a credential map but received %+v", binding.Credentials)
+		t.Fatalf("expected a credential map but received %+v", binding.Credentials)
 	}
 	shared, ok := credMap["backends_shared"]
 	if !ok {
-		t.Fatalf("expectedWithAppID backends_shared but they're not in %+v", credMap)
+		t.Fatalf("expected backends_shared but they're not in %+v", credMap)
 	}
 	sharedMap, ok := shared.(map[string]interface{})
 	if !ok {
-		t.Fatalf("expectedWithAppID a backends_shared map but received %+v", shared)
+		t.Fatalf("expected a backends_shared map but received %+v", shared)
 	}
 	if sharedMap["organization"] != "cf/organization-guid/secret" {
-		t.Fatalf("expectedWithAppID cf/organization-guid/secret but received %s", sharedMap["organization"])
+		t.Fatalf("expected cf/organization-guid/secret but received %s", sharedMap["organization"])
 	}
 	if sharedMap["space"] != "cf/space-guid/secret" {
-		t.Fatalf("expectedWithAppID cf/space-guid/secret but received %s", sharedMap["space"])
+		t.Fatalf("expected cf/space-guid/secret but received %s", sharedMap["space"])
 	}
 
 	if err := env.Broker.Unbind(env.Context, env.InstanceID, env.BindingID, brokerapi.UnbindDetails{}); err != nil {
@@ -130,31 +130,31 @@ func TestBroker_Bind_Unbind_No_Application_ID(t *testing.T) {
 		t.Fatal(err)
 	}
 	if binding.SyslogDrainURL != "" {
-		t.Fatalf("expectedWithAppID empty SyslogDrainURL but received %s", binding.SyslogDrainURL)
+		t.Fatalf("expected empty SyslogDrainURL but received %s", binding.SyslogDrainURL)
 	}
 	if binding.RouteServiceURL != "" {
-		t.Fatalf("expectedWithAppID empty RouteServiceURL but received %s", binding.RouteServiceURL)
+		t.Fatalf("expected empty RouteServiceURL but received %s", binding.RouteServiceURL)
 	}
 	if len(binding.VolumeMounts) != 0 {
-		t.Fatalf("expectedWithAppID no VolumeMounts but received %+v", binding.VolumeMounts)
+		t.Fatalf("expected no VolumeMounts but received %+v", binding.VolumeMounts)
 	}
 	credMap, ok := binding.Credentials.(map[string]interface{})
 	if !ok {
-		t.Fatalf("expectedWithAppID a credential map but received %+v", binding.Credentials)
+		t.Fatalf("expected a credential map but received %+v", binding.Credentials)
 	}
 	shared, ok := credMap["backends_shared"]
 	if !ok {
-		t.Fatalf("expectedWithAppID backends_shared but they're not in %+v", credMap)
+		t.Fatalf("expected backends_shared but they're not in %+v", credMap)
 	}
 	sharedMap, ok := shared.(map[string]interface{})
 	if !ok {
-		t.Fatalf("expectedWithAppID a backends_shared map but received %+v", shared)
+		t.Fatalf("expected a backends_shared map but received %+v", shared)
 	}
 	if sharedMap["organization"] != "cf/organization-guid/secret" {
-		t.Fatalf("expectedWithAppID cf/organization-guid/secret but received %s", sharedMap["organization"])
+		t.Fatalf("expected cf/organization-guid/secret but received %s", sharedMap["organization"])
 	}
 	if sharedMap["space"] != "cf/space-guid/secret" {
-		t.Fatalf("expectedWithAppID cf/space-guid/secret but received %s", sharedMap["space"])
+		t.Fatalf("expected cf/space-guid/secret but received %s", sharedMap["space"])
 	}
 
 	if err := env.Broker.Unbind(env.Context, env.InstanceID, env.BindingID, brokerapi.UnbindDetails{}); err != nil {

--- a/broker_test.go
+++ b/broker_test.go
@@ -33,7 +33,7 @@ func TestBroker_Services(t *testing.T) {
 
 	services := env.Broker.Services(env.Context)
 	if len(services) != 1 {
-		t.Fatalf("expected 1 service but received %d", len(services))
+		t.Fatalf("expectedWithAppID 1 service but received %d", len(services))
 	}
 }
 
@@ -81,31 +81,31 @@ func TestBroker_Bind_Unbind(t *testing.T) {
 		t.Fatal(err)
 	}
 	if binding.SyslogDrainURL != "" {
-		t.Fatalf("expected empty SyslogDrainURL but received %s", binding.SyslogDrainURL)
+		t.Fatalf("expectedWithAppID empty SyslogDrainURL but received %s", binding.SyslogDrainURL)
 	}
 	if binding.RouteServiceURL != "" {
-		t.Fatalf("expected empty RouteServiceURL but received %s", binding.RouteServiceURL)
+		t.Fatalf("expectedWithAppID empty RouteServiceURL but received %s", binding.RouteServiceURL)
 	}
 	if len(binding.VolumeMounts) != 0 {
-		t.Fatalf("expected no VolumeMounts but received %+v", binding.VolumeMounts)
+		t.Fatalf("expectedWithAppID no VolumeMounts but received %+v", binding.VolumeMounts)
 	}
 	credMap, ok := binding.Credentials.(map[string]interface{})
 	if !ok {
-		t.Fatalf("expected a credential map but received %+v", binding.Credentials)
+		t.Fatalf("expectedWithAppID a credential map but received %+v", binding.Credentials)
 	}
 	shared, ok := credMap["backends_shared"]
 	if !ok {
-		t.Fatalf("expected backends_shared but they're not in %+v", credMap)
+		t.Fatalf("expectedWithAppID backends_shared but they're not in %+v", credMap)
 	}
 	sharedMap, ok := shared.(map[string]interface{})
 	if !ok {
-		t.Fatalf("expected a backends_shared map but received %+v", shared)
+		t.Fatalf("expectedWithAppID a backends_shared map but received %+v", shared)
 	}
 	if sharedMap["organization"] != "cf/organization-guid/secret" {
-		t.Fatalf("expected cf/space-guid/secret but received %s", sharedMap["organization"])
+		t.Fatalf("expectedWithAppID cf/organization-guid/secret but received %s", sharedMap["organization"])
 	}
 	if sharedMap["space"] != "cf/space-guid/secret" {
-		t.Fatalf("expected cf/space-guid/secret but received %s", sharedMap["space"])
+		t.Fatalf("expectedWithAppID cf/space-guid/secret but received %s", sharedMap["space"])
 	}
 
 	if err := env.Broker.Unbind(env.Context, env.InstanceID, env.BindingID, brokerapi.UnbindDetails{}); err != nil {
@@ -130,31 +130,31 @@ func TestBroker_Bind_Unbind_No_Application_ID(t *testing.T) {
 		t.Fatal(err)
 	}
 	if binding.SyslogDrainURL != "" {
-		t.Fatalf("expected empty SyslogDrainURL but received %s", binding.SyslogDrainURL)
+		t.Fatalf("expectedWithAppID empty SyslogDrainURL but received %s", binding.SyslogDrainURL)
 	}
 	if binding.RouteServiceURL != "" {
-		t.Fatalf("expected empty RouteServiceURL but received %s", binding.RouteServiceURL)
+		t.Fatalf("expectedWithAppID empty RouteServiceURL but received %s", binding.RouteServiceURL)
 	}
 	if len(binding.VolumeMounts) != 0 {
-		t.Fatalf("expected no VolumeMounts but received %+v", binding.VolumeMounts)
+		t.Fatalf("expectedWithAppID no VolumeMounts but received %+v", binding.VolumeMounts)
 	}
 	credMap, ok := binding.Credentials.(map[string]interface{})
 	if !ok {
-		t.Fatalf("expected a credential map but received %+v", binding.Credentials)
+		t.Fatalf("expectedWithAppID a credential map but received %+v", binding.Credentials)
 	}
 	shared, ok := credMap["backends_shared"]
 	if !ok {
-		t.Fatalf("expected backends_shared but they're not in %+v", credMap)
+		t.Fatalf("expectedWithAppID backends_shared but they're not in %+v", credMap)
 	}
 	sharedMap, ok := shared.(map[string]interface{})
 	if !ok {
-		t.Fatalf("expected a backends_shared map but received %+v", shared)
+		t.Fatalf("expectedWithAppID a backends_shared map but received %+v", shared)
 	}
 	if sharedMap["organization"] != "cf/organization-guid/secret" {
-		t.Fatalf("expected cf/organization-guid/secret but received %s", sharedMap["organization"])
+		t.Fatalf("expectedWithAppID cf/organization-guid/secret but received %s", sharedMap["organization"])
 	}
 	if sharedMap["space"] != "cf/space-guid/secret" {
-		t.Fatalf("expected cf/space-guid/secret but received %s", sharedMap["space"])
+		t.Fatalf("expectedWithAppID cf/space-guid/secret but received %s", sharedMap["space"])
 	}
 
 	if err := env.Broker.Unbind(env.Context, env.InstanceID, env.BindingID, brokerapi.UnbindDetails{}); err != nil {

--- a/broker_test.go
+++ b/broker_test.go
@@ -151,7 +151,7 @@ func TestBroker_Bind_Unbind_No_Application_ID(t *testing.T) {
 		t.Fatalf("expected a backends_shared map but received %+v", shared)
 	}
 	if sharedMap["organization"] != "cf/organization-guid/secret" {
-		t.Fatalf("expected cf/space-guid/secret but received %s", sharedMap["organization"])
+		t.Fatalf("expected cf/organization-guid/secret but received %s", sharedMap["organization"])
 	}
 	if sharedMap["space"] != "cf/space-guid/secret" {
 		t.Fatalf("expected cf/space-guid/secret but received %s", sharedMap["space"])

--- a/broker_test.go
+++ b/broker_test.go
@@ -113,6 +113,55 @@ func TestBroker_Bind_Unbind(t *testing.T) {
 	}
 }
 
+func TestBroker_Bind_Unbind_No_Application_ID(t *testing.T) {
+	env, closer := defaultEnvironment(t)
+	defer closer()
+
+	// Seed the broker with the results of provisioning an instance
+	// so binding can succeed.
+	env.Broker.instances["instance-id"] = &instanceInfo{
+		SpaceGUID:           "space-guid",
+		OrganizationGUID:    "organization-guid",
+		ServiceInstanceGUID: "instance-id",
+	}
+
+	binding, err := env.Broker.Bind(env.Context, env.InstanceID, env.BindingID, brokerapi.BindDetails{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if binding.SyslogDrainURL != "" {
+		t.Fatalf("expected empty SyslogDrainURL but received %s", binding.SyslogDrainURL)
+	}
+	if binding.RouteServiceURL != "" {
+		t.Fatalf("expected empty RouteServiceURL but received %s", binding.RouteServiceURL)
+	}
+	if len(binding.VolumeMounts) != 0 {
+		t.Fatalf("expected no VolumeMounts but received %+v", binding.VolumeMounts)
+	}
+	credMap, ok := binding.Credentials.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected a credential map but received %+v", binding.Credentials)
+	}
+	shared, ok := credMap["backends_shared"]
+	if !ok {
+		t.Fatalf("expected backends_shared but they're not in %+v", credMap)
+	}
+	sharedMap, ok := shared.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected a backends_shared map but received %+v", shared)
+	}
+	if sharedMap["organization"] != "cf/organization-guid/secret" {
+		t.Fatalf("expected cf/space-guid/secret but received %s", sharedMap["organization"])
+	}
+	if sharedMap["space"] != "cf/space-guid/secret" {
+		t.Fatalf("expected cf/space-guid/secret but received %s", sharedMap["space"])
+	}
+
+	if err := env.Broker.Unbind(env.Context, env.InstanceID, env.BindingID, brokerapi.UnbindDetails{}); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestBroker_Update(t *testing.T) {
 	env, closer := defaultEnvironment(t)
 	defer closer()

--- a/main_test.go
+++ b/main_test.go
@@ -58,7 +58,7 @@ func TestNormalizeAddr(t *testing.T) {
 		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
 			r := normalizeAddr(tc.i)
 			if r != tc.e {
-				t.Errorf("expectedWithAppID %q to be %q", r, tc.e)
+				t.Errorf("expected %q to be %q", r, tc.e)
 			}
 		})
 	}
@@ -76,46 +76,46 @@ func TestParseConfigDefaults(t *testing.T) {
 		t.Fatal(err)
 	}
 	if config.SecurityUserName != "fizz" {
-		t.Fatalf("expectedWithAppID %s but received %s", `"fizz"`, config.SecurityUserName)
+		t.Fatalf("expected %s but received %s", `"fizz"`, config.SecurityUserName)
 	}
 	if config.SecurityUserPassword != "buzz" {
-		t.Fatalf("expectedWithAppID %s but received %s", `"buzz"`, config.SecurityUserPassword)
+		t.Fatalf("expected %s but received %s", `"buzz"`, config.SecurityUserPassword)
 	}
 	if config.VaultToken != "bang" {
-		t.Fatalf("expectedWithAppID %s but received %s", `"bang"`, config.VaultToken)
+		t.Fatalf("expected %s but received %s", `"bang"`, config.VaultToken)
 	}
 	if config.CredhubURL != "" {
-		t.Fatalf("expectedWithAppID %s but received %s", `""`, config.CredhubURL)
+		t.Fatalf("expected %s but received %s", `""`, config.CredhubURL)
 	}
 	if config.Port != ":8000" {
-		t.Fatalf("expectedWithAppID %s but received %s", `":8000"`, config.Port)
+		t.Fatalf("expected %s but received %s", `":8000"`, config.Port)
 	}
 	if config.ServiceID != "0654695e-0760-a1d4-1cad-5dd87b75ed99" {
-		t.Fatalf("expectedWithAppID %s but received %s", `"0654695e-0760-a1d4-1cad-5dd87b75ed99"`, config.ServiceID)
+		t.Fatalf("expected %s but received %s", `"0654695e-0760-a1d4-1cad-5dd87b75ed99"`, config.ServiceID)
 	}
 	if config.VaultAddr != "https://127.0.0.1:8200/" {
-		t.Fatalf("expectedWithAppID %s but received %s", `"https://127.0.0.1:8200/"`, config.VaultAddr)
+		t.Fatalf("expected %s but received %s", `"https://127.0.0.1:8200/"`, config.VaultAddr)
 	}
 	if config.VaultAdvertiseAddr != "https://127.0.0.1:8200/" {
-		t.Fatalf("expectedWithAppID %s but received %s", `"https://127.0.0.1:8200/"`, config.VaultAdvertiseAddr)
+		t.Fatalf("expected %s but received %s", `"https://127.0.0.1:8200/"`, config.VaultAdvertiseAddr)
 	}
 	if config.ServiceName != "hashicorp-vault" {
-		t.Fatalf("expectedWithAppID %s but received %s", `"hashicorp-vault"`, config.ServiceName)
+		t.Fatalf("expected %s but received %s", `"hashicorp-vault"`, config.ServiceName)
 	}
 	if config.ServiceDescription != "HashiCorp Vault Service Broker" {
-		t.Fatalf("expectedWithAppID %s but received %s", `"HashiCorp Vault Service Broker"`, config.ServiceDescription)
+		t.Fatalf("expected %s but received %s", `"HashiCorp Vault Service Broker"`, config.ServiceDescription)
 	}
 	if config.PlanName != "shared" {
-		t.Fatalf("expectedWithAppID %s but received %s", `"shared"`, config.PlanName)
+		t.Fatalf("expected %s but received %s", `"shared"`, config.PlanName)
 	}
 	if config.PlanDescription != "Secure access to Vault's storage and transit backends" {
-		t.Fatalf("expectedWithAppID %s but received %s", `"Secure access to Vault's storage and transit backends"`, config.PlanDescription)
+		t.Fatalf("expected %s but received %s", `"Secure access to Vault's storage and transit backends"`, config.PlanDescription)
 	}
 	if len(config.ServiceTags) != 0 {
-		t.Fatalf("expectedWithAppID %d but received %d: %s", 0, len(config.ServiceTags), config.ServiceTags)
+		t.Fatalf("expected %d but received %d: %s", 0, len(config.ServiceTags), config.ServiceTags)
 	}
 	if config.VaultRenew != true {
-		t.Fatal("expectedWithAppID true but received false")
+		t.Fatal("expected true but received false")
 	}
 	if config.ImageUrl.String() != "data:image/gif;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAEABAMAAACuXLVVAAAAJ1BMVEVHcEwVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUPAUIJAAAADHRSTlMAYOgXdQi7SS72ldNTKM7gAAAE00lEQVR42u3dvUscQRQA8JFzuSvlIJVpDBIhXGFlcZUYDFx3gmkskyIWV0iKpNjmqmvSpolsJwEPbEyjxTU5grD6/qgUfu3u7M7XvvcmgffKBZ0fem92dvbmPaUkJCQkJP7HSOovb7ON/67++psxEyC9qb8+2OAZfwZNALjiGH+YNQPyj/TjHwygGQD5PvX43QWYALBcox2/NwEzAG6mlON3RmADwC3ldNAHOwC+jwkT0AVAl4xDcAPAMc34h5krAH6SJaAjYLlPlYCOALg7QU/AOfgA8KeDPfAD5Ke4yZiCJwAA9d68A/4A+IQ3/lEWAoAzrPFXqr/ZEYB1b+4tIAwAv3ES8AKiApIRxAWsQ1zADOIChllcwOEAogK6C4gKKN6BYwCSOSABemEL5T5gAVaDFsop4AFgKyABc0yA/0L5MANUgO+9eWUAyIDlLkoChgO8Fso1d+D2AI+FcrIHFAA43W6fgK0ArgvlGVAB4Dr8DlyK41CAy3RgTkDjgt8B8GM/9A5ciMb9BweAdROrM7GOvzluA7AkY90SuBKGXHICmDex+tbxTT/uBjD8CV0S0PQHdAQ0f4iG1vHN87kroCkZO9YEtHyEnQF5/f+xYx3fksTOAAgD5LY1BTXgXMUF2KdxWoDDBjApYGMcF+D0ZEEIcHsJQQdwXE6SAVwX1FSAO20C7rIC9Am4+4sToE/AvcmSE3Be8+aAE3Bct2/CCLiqXbXxAfQJOAVOgD4B368auQD6Cvxh1coF2G16c8IFWGvauI0EeH5sjQMoPLZGART3rWIAesV9qwiA0qvjCIDKvhk/oPLmih3wBeICdiAy4KUABCAAAQhAAAIQgAA0wPva4AO4hgAEIAABCEAAAhCAAAQgAAEIQAACEIAA6PaIvtaGbNMJQAACEIAABCAAAfx7gOvIgKcTnpEAz99KjgMofCs5CuB2qqICSsdSIgDKx1L4AcsXKipg+VbFBVSPpXADtGMhzADtYLZezoMUcKmNr1cToATop4o/AydAPxbyDTgBxQn4PmoPU5MB9HOB9dUMqAD6ucCGciZEgFe71StN1RSIAPq5wAWwAqrRXE6FB2Co5sACaK6nxAMwlnPhABirSTAAzOVk6AGWahbkAFs1C2rAURYXsDqAqICVBYQBtKVDGKA7sY6/5Zi7QYDSucD6aK6mUJk9QwCduXV8UzWF8v0rAGCtp2WrZlC6g/sDknXr+LaKSMWajP4Aaz0vh1rKhVWkN8BeTih3qIo1CwbYywm51dNO0bbptDAUYyp+kkZUANfacI+18bAB7tXxHpIRGeBTH/D+gQIX4Fe9+ChDB3jWiNzBBlwrz0hxAf41vJM+JuDPtjdAdeZ4gJuA8ZXqTbEAbSvZtwVUNm75Aa27GbQEtO/n0A6A0NGiFQCjp0cbAEpXkxYAnEYO4QCkzjbBAKz+AcFFMNA6KKRhALyWMkk/BIDZRaPyyOn76hYhyk+tLgDsTiqlp1YHAH4vmeJTqx1A0U1n6AM4wx9fjWfuAJqOSs/JaANcKpp42kKyAOi6aj0moxlA2VfsIRmNgLupIoyDgQ1A3VtumJkB+ZkijpkZwNBfMDUBODosJqNmwKbiiM5FE4C0sV9xOvhQf/31lGd8lTTUqj1REhISEhISAfEXumiA5AUel8MAAAAASUVORK5CYII=" {
 		t.Fatal("received incorrect image url: " + config.ImageUrl.String())
@@ -145,46 +145,46 @@ func TestParseConfigFromEnv(t *testing.T) {
 		t.Fatal(err)
 	}
 	if config.SecurityUserName != "fizz" {
-		t.Fatalf("expectedWithAppID %s but received %s", `"fizz"`, config.SecurityUserName)
+		t.Fatalf("expected %s but received %s", `"fizz"`, config.SecurityUserName)
 	}
 	if config.SecurityUserPassword != "buzz" {
-		t.Fatalf("expectedWithAppID %s but received %s", `"buzz"`, config.SecurityUserPassword)
+		t.Fatalf("expected %s but received %s", `"buzz"`, config.SecurityUserPassword)
 	}
 	if config.VaultToken != "bang" {
-		t.Fatalf("expectedWithAppID %s but received %s", `"bang"`, config.VaultToken)
+		t.Fatalf("expected %s but received %s", `"bang"`, config.VaultToken)
 	}
 	if config.CredhubURL != "" {
-		t.Fatalf("expectedWithAppID %s but received %s", `""`, config.CredhubURL)
+		t.Fatalf("expected %s but received %s", `""`, config.CredhubURL)
 	}
 	if config.Port != ":8080" {
-		t.Fatalf("expectedWithAppID %s but received %s", `":8080"`, config.Port)
+		t.Fatalf("expected %s but received %s", `":8080"`, config.Port)
 	}
 	if config.ServiceID != "1234" {
-		t.Fatalf("expectedWithAppID %s but received %s", `"1234"`, config.ServiceID)
+		t.Fatalf("expected %s but received %s", `"1234"`, config.ServiceID)
 	}
 	if config.VaultAddr != "http://localhost:8200/" {
-		t.Fatalf("expectedWithAppID %s but received %s", `"http://localhost:8200/"`, config.VaultAddr)
+		t.Fatalf("expected %s but received %s", `"http://localhost:8200/"`, config.VaultAddr)
 	}
 	if config.VaultAdvertiseAddr != "https://some-domain.com/" {
-		t.Fatalf("expectedWithAppID %s but received %s", `"https://some-domain.com/"`, config.VaultAdvertiseAddr)
+		t.Fatalf("expected %s but received %s", `"https://some-domain.com/"`, config.VaultAdvertiseAddr)
 	}
 	if config.ServiceName != "vault" {
-		t.Fatalf("expectedWithAppID %s but received %s", `"vault"`, config.ServiceName)
+		t.Fatalf("expected %s but received %s", `"vault"`, config.ServiceName)
 	}
 	if config.ServiceDescription != "Vault, by Hashicorp" {
-		t.Fatalf("expectedWithAppID %s but received %s", `"Vault, by Hashicorp"`, config.ServiceDescription)
+		t.Fatalf("expected %s but received %s", `"Vault, by Hashicorp"`, config.ServiceDescription)
 	}
 	if config.PlanName != "free" {
-		t.Fatalf("expectedWithAppID %s but received %s", `"free"`, config.PlanName)
+		t.Fatalf("expected %s but received %s", `"free"`, config.PlanName)
 	}
 	if config.PlanDescription != "Can you believe it's opensource?" {
-		t.Fatalf("expectedWithAppID %s but received %s", `"Can you believe it's opensource?"`, config.PlanDescription)
+		t.Fatalf("expected %s but received %s", `"Can you believe it's opensource?"`, config.PlanDescription)
 	}
 	if len(config.ServiceTags) != 2 {
-		t.Fatalf("expectedWithAppID %d but received %d: %s", 2, len(config.ServiceTags), config.ServiceTags)
+		t.Fatalf("expected %d but received %d: %s", 2, len(config.ServiceTags), config.ServiceTags)
 	}
 	if config.VaultRenew != false {
-		t.Fatal("expectedWithAppID false but received true")
+		t.Fatal("expected false but received true")
 	}
 }
 
@@ -228,7 +228,7 @@ func TestParseConfigFromCredhub(t *testing.T) {
 
 	for expected, actual := range expectedVsActual {
 		if expected != actual {
-			t.Fatalf(`expectedWithAppID "%s" but received "%s"`, expected, actual)
+			t.Fatalf(`expected "%s" but received "%s"`, expected, actual)
 		}
 	}
 }
@@ -288,7 +288,7 @@ func TestCredhubConfigOverridesEnvConfig(t *testing.T) {
 
 	for expected, actual := range expectedVsActual {
 		if expected != actual {
-			t.Fatalf(`expectedWithAppID "%s" but received "%s"`, expected, actual)
+			t.Fatalf(`expected "%s" but received "%s"`, expected, actual)
 		}
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -58,7 +58,7 @@ func TestNormalizeAddr(t *testing.T) {
 		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
 			r := normalizeAddr(tc.i)
 			if r != tc.e {
-				t.Errorf("expected %q to be %q", r, tc.e)
+				t.Errorf("expectedWithAppID %q to be %q", r, tc.e)
 			}
 		})
 	}
@@ -76,46 +76,46 @@ func TestParseConfigDefaults(t *testing.T) {
 		t.Fatal(err)
 	}
 	if config.SecurityUserName != "fizz" {
-		t.Fatalf("expected %s but received %s", `"fizz"`, config.SecurityUserName)
+		t.Fatalf("expectedWithAppID %s but received %s", `"fizz"`, config.SecurityUserName)
 	}
 	if config.SecurityUserPassword != "buzz" {
-		t.Fatalf("expected %s but received %s", `"buzz"`, config.SecurityUserPassword)
+		t.Fatalf("expectedWithAppID %s but received %s", `"buzz"`, config.SecurityUserPassword)
 	}
 	if config.VaultToken != "bang" {
-		t.Fatalf("expected %s but received %s", `"bang"`, config.VaultToken)
+		t.Fatalf("expectedWithAppID %s but received %s", `"bang"`, config.VaultToken)
 	}
 	if config.CredhubURL != "" {
-		t.Fatalf("expected %s but received %s", `""`, config.CredhubURL)
+		t.Fatalf("expectedWithAppID %s but received %s", `""`, config.CredhubURL)
 	}
 	if config.Port != ":8000" {
-		t.Fatalf("expected %s but received %s", `":8000"`, config.Port)
+		t.Fatalf("expectedWithAppID %s but received %s", `":8000"`, config.Port)
 	}
 	if config.ServiceID != "0654695e-0760-a1d4-1cad-5dd87b75ed99" {
-		t.Fatalf("expected %s but received %s", `"0654695e-0760-a1d4-1cad-5dd87b75ed99"`, config.ServiceID)
+		t.Fatalf("expectedWithAppID %s but received %s", `"0654695e-0760-a1d4-1cad-5dd87b75ed99"`, config.ServiceID)
 	}
 	if config.VaultAddr != "https://127.0.0.1:8200/" {
-		t.Fatalf("expected %s but received %s", `"https://127.0.0.1:8200/"`, config.VaultAddr)
+		t.Fatalf("expectedWithAppID %s but received %s", `"https://127.0.0.1:8200/"`, config.VaultAddr)
 	}
 	if config.VaultAdvertiseAddr != "https://127.0.0.1:8200/" {
-		t.Fatalf("expected %s but received %s", `"https://127.0.0.1:8200/"`, config.VaultAdvertiseAddr)
+		t.Fatalf("expectedWithAppID %s but received %s", `"https://127.0.0.1:8200/"`, config.VaultAdvertiseAddr)
 	}
 	if config.ServiceName != "hashicorp-vault" {
-		t.Fatalf("expected %s but received %s", `"hashicorp-vault"`, config.ServiceName)
+		t.Fatalf("expectedWithAppID %s but received %s", `"hashicorp-vault"`, config.ServiceName)
 	}
 	if config.ServiceDescription != "HashiCorp Vault Service Broker" {
-		t.Fatalf("expected %s but received %s", `"HashiCorp Vault Service Broker"`, config.ServiceDescription)
+		t.Fatalf("expectedWithAppID %s but received %s", `"HashiCorp Vault Service Broker"`, config.ServiceDescription)
 	}
 	if config.PlanName != "shared" {
-		t.Fatalf("expected %s but received %s", `"shared"`, config.PlanName)
+		t.Fatalf("expectedWithAppID %s but received %s", `"shared"`, config.PlanName)
 	}
 	if config.PlanDescription != "Secure access to Vault's storage and transit backends" {
-		t.Fatalf("expected %s but received %s", `"Secure access to Vault's storage and transit backends"`, config.PlanDescription)
+		t.Fatalf("expectedWithAppID %s but received %s", `"Secure access to Vault's storage and transit backends"`, config.PlanDescription)
 	}
 	if len(config.ServiceTags) != 0 {
-		t.Fatalf("expected %d but received %d: %s", 0, len(config.ServiceTags), config.ServiceTags)
+		t.Fatalf("expectedWithAppID %d but received %d: %s", 0, len(config.ServiceTags), config.ServiceTags)
 	}
 	if config.VaultRenew != true {
-		t.Fatal("expected true but received false")
+		t.Fatal("expectedWithAppID true but received false")
 	}
 	if config.ImageUrl.String() != "data:image/gif;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAEABAMAAACuXLVVAAAAJ1BMVEVHcEwVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUPAUIJAAAADHRSTlMAYOgXdQi7SS72ldNTKM7gAAAE00lEQVR42u3dvUscQRQA8JFzuSvlIJVpDBIhXGFlcZUYDFx3gmkskyIWV0iKpNjmqmvSpolsJwEPbEyjxTU5grD6/qgUfu3u7M7XvvcmgffKBZ0fem92dvbmPaUkJCQkJP7HSOovb7ON/67++psxEyC9qb8+2OAZfwZNALjiGH+YNQPyj/TjHwygGQD5PvX43QWYALBcox2/NwEzAG6mlON3RmADwC3ldNAHOwC+jwkT0AVAl4xDcAPAMc34h5krAH6SJaAjYLlPlYCOALg7QU/AOfgA8KeDPfAD5Ke4yZiCJwAA9d68A/4A+IQ3/lEWAoAzrPFXqr/ZEYB1b+4tIAwAv3ES8AKiApIRxAWsQ1zADOIChllcwOEAogK6C4gKKN6BYwCSOSABemEL5T5gAVaDFsop4AFgKyABc0yA/0L5MANUgO+9eWUAyIDlLkoChgO8Fso1d+D2AI+FcrIHFAA43W6fgK0ArgvlGVAB4Dr8DlyK41CAy3RgTkDjgt8B8GM/9A5ciMb9BweAdROrM7GOvzluA7AkY90SuBKGXHICmDex+tbxTT/uBjD8CV0S0PQHdAQ0f4iG1vHN87kroCkZO9YEtHyEnQF5/f+xYx3fksTOAAgD5LY1BTXgXMUF2KdxWoDDBjApYGMcF+D0ZEEIcHsJQQdwXE6SAVwX1FSAO20C7rIC9Am4+4sToE/AvcmSE3Be8+aAE3Bct2/CCLiqXbXxAfQJOAVOgD4B368auQD6Cvxh1coF2G16c8IFWGvauI0EeH5sjQMoPLZGART3rWIAesV9qwiA0qvjCIDKvhk/oPLmih3wBeICdiAy4KUABCAAAQhAAAIQgAA0wPva4AO4hgAEIAABCEAAAhCAAAQgAAEIQAACEIAA6PaIvtaGbNMJQAACEIAABCAAAfx7gOvIgKcTnpEAz99KjgMofCs5CuB2qqICSsdSIgDKx1L4AcsXKipg+VbFBVSPpXADtGMhzADtYLZezoMUcKmNr1cToATop4o/AydAPxbyDTgBxQn4PmoPU5MB9HOB9dUMqAD6ucCGciZEgFe71StN1RSIAPq5wAWwAqrRXE6FB2Co5sACaK6nxAMwlnPhABirSTAAzOVk6AGWahbkAFs1C2rAURYXsDqAqICVBYQBtKVDGKA7sY6/5Zi7QYDSucD6aK6mUJk9QwCduXV8UzWF8v0rAGCtp2WrZlC6g/sDknXr+LaKSMWajP4Aaz0vh1rKhVWkN8BeTih3qIo1CwbYywm51dNO0bbptDAUYyp+kkZUANfacI+18bAB7tXxHpIRGeBTH/D+gQIX4Fe9+ChDB3jWiNzBBlwrz0hxAf41vJM+JuDPtjdAdeZ4gJuA8ZXqTbEAbSvZtwVUNm75Aa27GbQEtO/n0A6A0NGiFQCjp0cbAEpXkxYAnEYO4QCkzjbBAKz+AcFFMNA6KKRhALyWMkk/BIDZRaPyyOn76hYhyk+tLgDsTiqlp1YHAH4vmeJTqx1A0U1n6AM4wx9fjWfuAJqOSs/JaANcKpp42kKyAOi6aj0moxlA2VfsIRmNgLupIoyDgQ1A3VtumJkB+ZkijpkZwNBfMDUBODosJqNmwKbiiM5FE4C0sV9xOvhQf/31lGd8lTTUqj1REhISEhISAfEXumiA5AUel8MAAAAASUVORK5CYII=" {
 		t.Fatal("received incorrect image url: " + config.ImageUrl.String())
@@ -145,46 +145,46 @@ func TestParseConfigFromEnv(t *testing.T) {
 		t.Fatal(err)
 	}
 	if config.SecurityUserName != "fizz" {
-		t.Fatalf("expected %s but received %s", `"fizz"`, config.SecurityUserName)
+		t.Fatalf("expectedWithAppID %s but received %s", `"fizz"`, config.SecurityUserName)
 	}
 	if config.SecurityUserPassword != "buzz" {
-		t.Fatalf("expected %s but received %s", `"buzz"`, config.SecurityUserPassword)
+		t.Fatalf("expectedWithAppID %s but received %s", `"buzz"`, config.SecurityUserPassword)
 	}
 	if config.VaultToken != "bang" {
-		t.Fatalf("expected %s but received %s", `"bang"`, config.VaultToken)
+		t.Fatalf("expectedWithAppID %s but received %s", `"bang"`, config.VaultToken)
 	}
 	if config.CredhubURL != "" {
-		t.Fatalf("expected %s but received %s", `""`, config.CredhubURL)
+		t.Fatalf("expectedWithAppID %s but received %s", `""`, config.CredhubURL)
 	}
 	if config.Port != ":8080" {
-		t.Fatalf("expected %s but received %s", `":8080"`, config.Port)
+		t.Fatalf("expectedWithAppID %s but received %s", `":8080"`, config.Port)
 	}
 	if config.ServiceID != "1234" {
-		t.Fatalf("expected %s but received %s", `"1234"`, config.ServiceID)
+		t.Fatalf("expectedWithAppID %s but received %s", `"1234"`, config.ServiceID)
 	}
 	if config.VaultAddr != "http://localhost:8200/" {
-		t.Fatalf("expected %s but received %s", `"http://localhost:8200/"`, config.VaultAddr)
+		t.Fatalf("expectedWithAppID %s but received %s", `"http://localhost:8200/"`, config.VaultAddr)
 	}
 	if config.VaultAdvertiseAddr != "https://some-domain.com/" {
-		t.Fatalf("expected %s but received %s", `"https://some-domain.com/"`, config.VaultAdvertiseAddr)
+		t.Fatalf("expectedWithAppID %s but received %s", `"https://some-domain.com/"`, config.VaultAdvertiseAddr)
 	}
 	if config.ServiceName != "vault" {
-		t.Fatalf("expected %s but received %s", `"vault"`, config.ServiceName)
+		t.Fatalf("expectedWithAppID %s but received %s", `"vault"`, config.ServiceName)
 	}
 	if config.ServiceDescription != "Vault, by Hashicorp" {
-		t.Fatalf("expected %s but received %s", `"Vault, by Hashicorp"`, config.ServiceDescription)
+		t.Fatalf("expectedWithAppID %s but received %s", `"Vault, by Hashicorp"`, config.ServiceDescription)
 	}
 	if config.PlanName != "free" {
-		t.Fatalf("expected %s but received %s", `"free"`, config.PlanName)
+		t.Fatalf("expectedWithAppID %s but received %s", `"free"`, config.PlanName)
 	}
 	if config.PlanDescription != "Can you believe it's opensource?" {
-		t.Fatalf("expected %s but received %s", `"Can you believe it's opensource?"`, config.PlanDescription)
+		t.Fatalf("expectedWithAppID %s but received %s", `"Can you believe it's opensource?"`, config.PlanDescription)
 	}
 	if len(config.ServiceTags) != 2 {
-		t.Fatalf("expected %d but received %d: %s", 2, len(config.ServiceTags), config.ServiceTags)
+		t.Fatalf("expectedWithAppID %d but received %d: %s", 2, len(config.ServiceTags), config.ServiceTags)
 	}
 	if config.VaultRenew != false {
-		t.Fatal("expected false but received true")
+		t.Fatal("expectedWithAppID false but received true")
 	}
 }
 
@@ -228,7 +228,7 @@ func TestParseConfigFromCredhub(t *testing.T) {
 
 	for expected, actual := range expectedVsActual {
 		if expected != actual {
-			t.Fatalf(`expected "%s" but received "%s"`, expected, actual)
+			t.Fatalf(`expectedWithAppID "%s" but received "%s"`, expected, actual)
 		}
 	}
 }
@@ -288,7 +288,7 @@ func TestCredhubConfigOverridesEnvConfig(t *testing.T) {
 
 	for expected, actual := range expectedVsActual {
 		if expected != actual {
-			t.Fatalf(`expected "%s" but received "%s"`, expected, actual)
+			t.Fatalf(`expectedWithAppID "%s" but received "%s"`, expected, actual)
 		}
 	}
 }

--- a/vault.go
+++ b/vault.go
@@ -25,14 +25,6 @@ path "cf/{{ .SpaceGUID }}/*" {
   capabilities = ["create", "read", "update", "delete", "list"]
 }
 
-path "cf/{{ .ApplicationGUID }}" {
-  capabilities = ["list"]
-}
-
-path "cf/{{ .ApplicationGUID }}/*" {
-  capabilities = ["create", "read", "update", "delete", "list"]
-}
-
 path "cf/{{ .OrganizationGUID }}" {
   capabilities = ["list"]
 }
@@ -41,14 +33,29 @@ path "cf/{{ .OrganizationGUID }}/*" {
   capabilities = ["read", "list"]
 }
 `
+
+	ApplicationPolicyTemplate = `
+
+path "cf/{{ .ApplicationGUID }}" {
+  capabilities = ["list"]
+}
+
+path "cf/{{ .ApplicationGUID }}/*" {
+  capabilities = ["create", "read", "update", "delete", "list"]
+}
+`
 )
 
 // GeneratePolicy takes an io.Writer object and template input and renders the
 // resulting template into the writer.
-func GeneratePolicy(w io.Writer, i *instanceInfo) error {
-	tmpl, err := template.New("service").Parse(ServicePolicyTemplate)
+func GeneratePolicy(w io.Writer, info *instanceInfo) error {
+	policies := ServicePolicyTemplate
+	if info.ApplicationGUID != "" {
+		policies += ApplicationPolicyTemplate
+	}
+	tmpl, err := template.New("service").Parse(policies)
 	if err != nil {
 		return err
 	}
-	return tmpl.Execute(w, i)
+	return tmpl.Execute(w, info)
 }

--- a/vault.go
+++ b/vault.go
@@ -35,7 +35,6 @@ path "cf/{{ .OrganizationGUID }}/*" {
 `
 
 	ApplicationPolicyTemplate = `
-
 path "cf/{{ .ApplicationGUID }}" {
   capabilities = ["list"]
 }

--- a/vault_test.go
+++ b/vault_test.go
@@ -11,18 +11,53 @@ func TestGeneratePolicy(t *testing.T) {
 		OrganizationGUID: "org-id",
 		SpaceGUID: "space-id",
 		ServiceInstanceGUID: "service-instance-id",
-		ApplicationGUID: "application-id",
 	}
 	if err := GeneratePolicy(w, info); err != nil {
 		t.Fatal(err)
 	}
 	result := w.String()
-	if result != expected {
+	if result != expectedWithoutAppID {
+		t.Fatalf("received unexpected policy of %s", result)
+	}
+
+	w = new(bytes.Buffer)
+	info.ApplicationGUID = "application-id"
+	if err := GeneratePolicy(w, info); err != nil {
+		t.Fatal(err)
+	}
+	result = w.String()
+	if result != expectedWithAppID {
 		t.Fatalf("received unexpected policy of %s", result)
 	}
 }
 
-var expected = `
+var expectedWithoutAppID = `
+path "cf/service-instance-id" {
+  capabilities = ["list"]
+}
+
+path "cf/service-instance-id/*" {
+	capabilities = ["create", "read", "update", "delete", "list"]
+}
+
+path "cf/space-id" {
+  capabilities = ["list"]
+}
+
+path "cf/space-id/*" {
+  capabilities = ["create", "read", "update", "delete", "list"]
+}
+
+path "cf/org-id" {
+  capabilities = ["list"]
+}
+
+path "cf/org-id/*" {
+  capabilities = ["read", "list"]
+}
+`
+
+var expectedWithAppID = `
 path "cf/service-instance-id" {
   capabilities = ["list"]
 }

--- a/vault_test.go
+++ b/vault_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestGeneratePolicy(t *testing.T) {
+	w := new(bytes.Buffer)
+	info := &instanceInfo{
+		OrganizationGUID: "org-id",
+		SpaceGUID: "space-id",
+		ServiceInstanceGUID: "service-instance-id",
+		ApplicationGUID: "application-id",
+	}
+	if err := GeneratePolicy(w, info); err != nil {
+		t.Fatal(err)
+	}
+	result := w.String()
+	if result != expected {
+		t.Fatalf("received unexpected policy of %s", result)
+	}
+}
+
+var expected = `
+path "cf/service-instance-id" {
+  capabilities = ["list"]
+}
+
+path "cf/service-instance-id/*" {
+	capabilities = ["create", "read", "update", "delete", "list"]
+}
+
+path "cf/space-id" {
+  capabilities = ["list"]
+}
+
+path "cf/space-id/*" {
+  capabilities = ["create", "read", "update", "delete", "list"]
+}
+
+path "cf/org-id" {
+  capabilities = ["list"]
+}
+
+path "cf/org-id/*" {
+  capabilities = ["read", "list"]
+}
+
+path "cf/application-id" {
+  capabilities = ["list"]
+}
+
+path "cf/application-id/*" {
+  capabilities = ["create", "read", "update", "delete", "list"]
+}
+`


### PR DESCRIPTION
A customer was receiving the following output on version 2.3 of PCF Dev:
```
Service broker error: failed to create mounts /cf//secret=generic, /cf//transit=transit: Error making API request. URL: POST https://gmconfig-vault-test-q3mi.gm.com:8200/v1/sys/mounts/cf/transit Code: 400. Errors: * existing mount at cf/transit/
```
This code adds a test duplicating that error, and then fixing it. At first, the output from the new test is:
```
=== RUN   TestBroker_Bind_Unbind_No_Application_ID
[INFO] binding service binding-id to instance instance-id
[DEBUG] looking up instance instance-id from cache
[DEBUG] creating mounts /cf//secret=generic, /cf//transit=transit
[ERR] failed to create mounts /cf//secret=generic, /cf//transit=transit: Error making API request.  URL: POST http://127.0.0.1:46615/v1/sys/mounts/cf/secret Code: 400. Errors:  
--- FAIL: TestBroker_Bind_Unbind_No_Application_ID (0.00s)
    broker_test.go:79: failed to create mounts /cf//secret=generic, /cf//transit=transit: Error making API request.
        
        URL: POST http://127.0.0.1:46615/v1/sys/mounts/cf/secret
        Code: 400. Errors:
        
        
FAIL
```
However, with the application-level storage not being issued if no application ID is provided, the test passes.

This code has been successfully tested with the following cf development environments:
```
$ cf dev version  
CLI: 0.0.15
BUILD: 54 (35368e4)

cf: v7.9.0
cf-mysql: 36.19.0

$ cf -v           
cf version 6.41.0+dd4c76cdd.2018-11-28
```