### PR TITLE
Don't error if accessor deleted

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -600,6 +600,10 @@ func (b *Broker) Unbind(ctx context.Context, instanceID, bindingID string, detai
 	a := info.Accessor
 	b.log.Printf("[DEBUG] revoking accessor %s for path %s", a, path)
 	if err := b.vaultClient.Auth().Token().RevokeAccessor(a); err != nil {
+		if strings.Contains(err.Error(), "invalid accessor") {
+			// The token has already been revoked.
+			return nil
+		}
 		return b.wErrorf(err, "failed to revoke accessor %s", a)
 	}
 

--- a/broker_test.go
+++ b/broker_test.go
@@ -420,6 +420,7 @@ func defaultEnvironment(t *testing.T) (*Environment, func()) {
 			return
 
 		case reqURL == "/v1/cf/broker/instance-id/binding-id" && r.Method == "DELETE":
+		case reqURL == "/v1/cf/broker/instance-id/bad-accessor-test" && r.Method == "DELETE":
 			w.WriteHeader(204)
 			return
 

--- a/vault_test.go
+++ b/vault_test.go
@@ -8,8 +8,8 @@ import (
 func TestGeneratePolicy(t *testing.T) {
 	w := new(bytes.Buffer)
 	info := &instanceInfo{
-		OrganizationGUID: "org-id",
-		SpaceGUID: "space-id",
+		OrganizationGUID:    "org-id",
+		SpaceGUID:           "space-id",
 		ServiceInstanceGUID: "service-instance-id",
 	}
 	if err := GeneratePolicy(w, info); err != nil {


### PR DESCRIPTION
Solves this error where an accessor may have expired or have been deleted out-of-band.
```
Service broker failed to delete service binding for instance test-broker: Service broker error: failed to revoke accessor foo: Error making API request. URL: POST https://localhost:8200/v1/auth/token/revoke-accessor Code: 400. Errors: * 1 error occurred: * invalid accessor
```