### PR TITLE
Instance Storage Update

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -442,9 +442,7 @@ func (b *Broker) Bind(ctx context.Context, instanceID, bindingID string, details
 	}
 
 	if details.AppGUID != "" {
-		// The details.AppGUID isn't _required_ to be provided per the Open Service Broker API spec;
-		// however, in testing PCF's behavior, we found that it's always populated by the platform on
-		// later versions, but isn't by earlier versions.
+		// The details.AppGUID isn't _required_ to be provided per the Open Service Broker API spec
 		instance.ApplicationGUID = details.AppGUID
 
 		// Ensure we have application-level mounts
@@ -548,9 +546,9 @@ func (b *Broker) Bind(ctx context.Context, instanceID, bindingID string, details
 	// Save the credentials
 	genericBackends := []string{"cf/" + instanceID + "/secret"}
 	transitBackends := []string{"cf/" + instanceID + "/transit"}
-	if details.AppGUID != "" {
-		genericBackends = append(genericBackends, "cf/"+details.AppGUID+"/secret")
-		transitBackends = append(transitBackends, "cf/"+details.AppGUID+"/transit")
+	if instance.ApplicationGUID != "" {
+		genericBackends = append(genericBackends, "cf/"+instance.ApplicationGUID+"/secret")
+		transitBackends = append(transitBackends, "cf/"+instance.ApplicationGUID+"/transit")
 	}
 	binding.Credentials = map[string]interface{}{
 		"address": b.vaultAdvertiseAddr,
@@ -565,6 +563,7 @@ func (b *Broker) Bind(ctx context.Context, instanceID, bindingID string, details
 		"backends_shared": map[string]interface{}{
 			"organization": "cf/" + instance.OrganizationGUID + "/secret",
 			"space":        "cf/" + instance.SpaceGUID + "/secret",
+			"application":  "cf/" + instance.ApplicationGUID + "/secret",
 		},
 	}
 	return binding, nil

--- a/broker_test.go
+++ b/broker_test.go
@@ -70,9 +70,8 @@ func TestBroker_Bind_Unbind(t *testing.T) {
 	// Seed the broker with the results of provisioning an instance
 	// so binding can succeed.
 	env.Broker.instances["instance-id"] = &instanceInfo{
-		SpaceGUID:           "space-guid",
-		OrganizationGUID:    "organization-guid",
-		ServiceInstanceGUID: "instance-id",
+		SpaceGUID:        "space-guid",
+		OrganizationGUID: "organization-guid",
 	}
 
 	binding, err := env.Broker.Bind(env.Context, env.InstanceID, env.BindingID, brokerapi.BindDetails{
@@ -121,9 +120,8 @@ func TestBroker_Bind_Unbind_No_Application_ID(t *testing.T) {
 	// Seed the broker with the results of provisioning an instance
 	// so binding can succeed.
 	env.Broker.instances["instance-id"] = &instanceInfo{
-		SpaceGUID:           "space-guid",
-		OrganizationGUID:    "organization-guid",
-		ServiceInstanceGUID: "instance-id",
+		SpaceGUID:        "space-guid",
+		OrganizationGUID: "organization-guid",
 	}
 
 	binding, err := env.Broker.Bind(env.Context, env.InstanceID, env.BindingID, brokerapi.BindDetails{})
@@ -170,9 +168,8 @@ func TestBroker_Bind_Unbind_No_Access_Token(t *testing.T) {
 	// Seed the broker with the results of provisioning an instance
 	// so binding can succeed.
 	env.Broker.instances["instance-id"] = &instanceInfo{
-		SpaceGUID:           "space-guid",
-		OrganizationGUID:    "organization-guid",
-		ServiceInstanceGUID: "instance-id",
+		SpaceGUID:        "space-guid",
+		OrganizationGUID: "organization-guid",
 	}
 
 	binding, err := env.Broker.Bind(env.Context, env.InstanceID, env.BindingID, brokerapi.BindDetails{

--- a/vault.go
+++ b/vault.go
@@ -9,50 +9,60 @@ const (
 	// ServicePolicyTemplate is the template used to generate a Vault policy on
 	// service create.
 	ServicePolicyTemplate string = `
-path "cf/{{ .ServiceInstanceGUID }}" {
+path "cf/{{ .InstanceID }}" {
   capabilities = ["list"]
 }
 
-path "cf/{{ .ServiceInstanceGUID }}/*" {
+path "cf/{{ .InstanceID }}/*" {
 	capabilities = ["create", "read", "update", "delete", "list"]
 }
 
-path "cf/{{ .SpaceGUID }}" {
+path "cf/{{ .SpaceID }}" {
   capabilities = ["list"]
 }
 
-path "cf/{{ .SpaceGUID }}/*" {
+path "cf/{{ .SpaceID }}/*" {
   capabilities = ["create", "read", "update", "delete", "list"]
 }
 
-path "cf/{{ .OrganizationGUID }}" {
+path "cf/{{ .OrgID }}" {
   capabilities = ["list"]
 }
 
-path "cf/{{ .OrganizationGUID }}/*" {
+path "cf/{{ .OrgID }}/*" {
   capabilities = ["read", "list"]
 }
-`
-
-	ApplicationPolicyTemplate = `
-path "cf/{{ .ApplicationGUID }}" {
+{{ if ne .ApplicationID "" }}
+path "cf/{{ .ApplicationID }}" {
   capabilities = ["list"]
 }
 
-path "cf/{{ .ApplicationGUID }}/*" {
+path "cf/{{ .ApplicationID }}/*" {
   capabilities = ["create", "read", "update", "delete", "list"]
 }
+{{ end -}}
 `
 )
 
+// ServicePolicyTemplateInput is used as input to the ServicePolicyTemplate.
+type ServicePolicyTemplateInput struct {
+	// InstanceID is the unique ID of the service instance.
+	InstanceID string
+
+	// SpaceID is the unique ID of the space.
+	SpaceID string
+
+	// OrgID is the unique ID of the space.
+	OrgID string
+
+	// ApplicationID is the unique ID of the service.
+	ApplicationID string
+}
+
 // GeneratePolicy takes an io.Writer object and template input and renders the
 // resulting template into the writer.
-func GeneratePolicy(w io.Writer, info *instanceInfo) error {
-	policies := ServicePolicyTemplate
-	if info.ApplicationGUID != "" {
-		policies += ApplicationPolicyTemplate
-	}
-	tmpl, err := template.New("service").Parse(policies)
+func GeneratePolicy(w io.Writer, info *ServicePolicyTemplateInput) error {
+	tmpl, err := template.New("service").Parse(ServicePolicyTemplate)
 	if err != nil {
 		return err
 	}

--- a/vault_test.go
+++ b/vault_test.go
@@ -7,10 +7,10 @@ import (
 
 func TestGeneratePolicy(t *testing.T) {
 	w := new(bytes.Buffer)
-	info := &instanceInfo{
-		OrganizationGUID:    "org-id",
-		SpaceGUID:           "space-id",
-		ServiceInstanceGUID: "service-instance-id",
+	info := &ServicePolicyTemplateInput{
+		OrgID:      "org-id",
+		SpaceID:    "space-id",
+		InstanceID: "service-instance-id",
 	}
 	if err := GeneratePolicy(w, info); err != nil {
 		t.Fatal(err)
@@ -21,7 +21,7 @@ func TestGeneratePolicy(t *testing.T) {
 	}
 
 	w = new(bytes.Buffer)
-	info.ApplicationGUID = "application-id"
+	info.ApplicationID = "application-id"
 	if err := GeneratePolicy(w, info); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Version 0.3.0 started to store instance id in the stored date for the instance.  This introduced a problem for users trying to upgrade because this value was not set in the stored data but only stored as the key.  This reverts that change and ignores any stored instance id.