### PR TITLE
docs: readme acl works using sys/policies/acl

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ path "sys/mounts/cf/*" {
 }
 
 # Create policies with the "cf-*" prefix
-path "sys/policy/cf-*" {
+path "sys/policies/acl/cf-*" {
   capabilities = ["create", "update", "delete"]
 }
 


### PR DESCRIPTION
When using the broker I was getting 403 when creating a binding, because `sys/policies/acl/cf-` was not covered by the broker's policy