### PR TITLE
Add semaphore throttle for startup renewals

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -19,7 +19,8 @@ import (
 
 const (
 	// VaultPeriodicTTL is the token role periodic TTL.
-	VaultPeriodicTTL = 5 * 24 * 60 * 60
+	VaultPeriodicTTL        = 5 * 24 * 60 * 60
+	RenewLimitChannelBuffer = 10
 )
 
 // Ensure we implement the broker API
@@ -111,7 +112,7 @@ func (b *Broker) Start() error {
 	b.stopCh = make(chan struct{})
 
 	// Create the semaphore channel for rate limiting during restoreBind
-	b.sem = make(chan struct{}, 20)
+	b.sem = make(chan struct{}, RenewLimitChannelBuffer)
 
 	// Start background renewal
 	if b.vaultRenewToken {


### PR DESCRIPTION
When the broker starts up, it reads all bindings in `/cf/broker` and needs to renew each of them to obtain a Lease ID for each token. The token and lease ID are then passed off to the Vault API renewer to keep the token alive.

If a significant amount of tokens are found in `/cf/broker`, the broker can overwhelm Vault with a lot of traffic. Here we add a semaphore that throttles the requests sent to Vault depending on how fast Vault can process them.