### PR TITLE
Use docker mirror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-    - image: circleci/golang:1.12
+    - image: docker.mirror.hashicorp.services/circleci/golang:1.12
     working_directory: /go/src/github.com/hashicorp/vault-service-broker
     steps:
     - checkout

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Builder
 #
-FROM golang:1.8 AS builder
+FROM docker.mirror.hashicorp.services/golang:1.8 AS builder
 LABEL maintainer "Seth Vargo <seth@sethvargo.com> (@sethvargo)"
 
 WORKDIR /go/src/github.com/hashicorp/vault-service-broker
@@ -20,7 +20,7 @@ RUN \
 #
 # Final
 #
-FROM scratch
+FROM docker.mirror.hashicorp.services/scratch
 LABEL maintainer "Seth Vargo <seth@sethvargo.com> (@sethvargo)"
 
 ADD "https://curl.haxx.se/ca/cacert.pem" "/etc/ssl/certs/ca-certificates.crt"


### PR DESCRIPTION
Instead of using dockerhub (which will enforce rate limiting on anonymous image pulls starting Nov 1st), we're moving projects to our mirror at `docker.mirror.hashicorp.services`. LMK if you have any q's, otherwise feel free to approve and merge on your own! 