### PR TITLE
version: bump to 0.5.4

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const Version = "0.5.3"
+const Version = "0.5.4"


### PR DESCRIPTION
Bump version to 0.5.4 for release cut. We will need to update CHANGELOG afterwards as well.