### PR TITLE
Remove vault http client redefinition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Cloud Foundry HashiCorp Vault Broker Changelog
 
+## Unreleased
+IMPROVEMENTS:
+- [#66](https://github.com/hashicorp/vault-service-broker/pull/66) allow environment variables like `VAULT_SKIP_VERIFY` to be picked up by the Vault client
+
 ## v0.5.4 (Dec 2, 2020)
 BUG FIXES:
 - [#57](https://github.com/hashicorp/vault-service-broker/pull/57) fixes an issue where the broker sends too many requests to Vault during startup

--- a/main.go
+++ b/main.go
@@ -38,7 +38,6 @@ func main() {
 
 	// Setup the vault client
 	vaultClientConfig := api.DefaultConfig()
-	vaultClientConfig.HttpClient = cleanhttp.DefaultClient()
 
 	vaultClient, err := api.NewClient(vaultClientConfig)
 	if err != nil {


### PR DESCRIPTION
Allows env variables like VAULT_SKIP_VERIFY to be picked up by the Vault client.

Tested by setting up a Vault server in dev mode with a TLS listener, and setting VAULT_SKIP_VERIFY for the service broker.

```shell
# configure Vault with TLS on port 8400
mkcert localhost

cat << EOF >> dev-tls-config.hcl
listener "tcp" {
  address       = "0.0.0.0:8400"
  tls_cert_file = "localhost.pem"
  tls_key_file  = "localhost-key.pem"
}
EOF

vault server -dev -log-level="debug" -dev-ha -dev-transactional -dev-root-token-id=root -config=dev-tls-config.hcl

# setup the broker
export VAULT_ADDR="https://localhost:8400"
export VAULT_TOKEN="root"
export VAULT_SKIP_VERIFY=true
export SECURITY_USER_NAME="vault"
export SECURITY_USER_PASSWORD="broker-secret-password"

go build
./vault-service-broker
```

Fixes #52 