### PR TITLE
version bump for 0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Cloud Foundry HashiCorp Vault Broker Changelog
 
-## Unreleased
+## v0.6.0 (Aug 11, 2022)
+CHANGES:
+- [#65](https://github.com/hashicorp/vault-service-broker/pull/65) migrated to go modules, use go 1.18 in tests, and updated to vault/api@v1.7.2
+
 IMPROVEMENTS:
 - [#66](https://github.com/hashicorp/vault-service-broker/pull/66) allow environment variables like `VAULT_SKIP_VERIFY` to be picked up by the Vault client
 

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const Version = "0.5.4"
+const Version = "0.6.0"


### PR DESCRIPTION
Plus changelog update.

Even though the code change in this release isn't big, the dep updates, go update, and go mod conversion seemed to warrant a new minor version.